### PR TITLE
feat!: use provider-specific exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/sanity-io/form-toolkit/compare/v1.2.0...v1.2.1) (2025-03-03)
+
+### Bug Fixes
+
+- formdata react error ([#8](https://github.com/sanity-io/form-toolkit/issues/8)) ([467442a](https://github.com/sanity-io/form-toolkit/commit/467442a21c34c10ae2e14343a34e08dde833addb))
+
 ## [1.2.0](https://github.com/sanity-io/form-toolkit/compare/v1.1.0...v1.2.0) (2025-02-03)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There's an "out of the box" handler for Next.js API routes:
 
 ```ts
 // pages/api/hubspot.ts
-import {hubSpotHandler} from '@sanity/form-toolkit'
+import {hubSpotHandler} from '@sanity/form-toolkit/hubspot'
 
 const handler = hubSpotHandler({
   token: process.env.HUBSPOT_TOKEN ?? '',
@@ -37,7 +37,7 @@ Or add `fetchHubSpotData` to an API route in your non-Next framework
 
 ```ts
 // my-nuxt-app/server/api/hubspot.ts
-import {fetchHubSpotData} from '@sanity/form-toolkit'
+import {fetchHubSpotData} from '@sanity/form-toolkit/hubspot'
 
 export default defineEventHandler(async (event) => {
   const req = event.node.req
@@ -54,7 +54,7 @@ Add it as a plugin in `sanity.config.ts` (or .js):
 
 ```ts
 import {defineConfig} from 'sanity'
-import {hubSpotInput} from '@sanity/form-toolkit'
+import {hubSpotInput} from '@sanity/form-toolkit/hubspot'
 
 export default defineConfig({
   //...
@@ -96,7 +96,7 @@ There's an "out of the box" handler for Next.js API routes:
 
 ```ts
 // pages/api/mailchimp.ts
-import {mailchimpHandler} from '@sanity/form-toolkit'
+import {mailchimpHandler} from '@sanity/form-toolkit/mailchimp'
 
 const handler = mailchimpHandler({
   key: process.env.MAILCHIMP_KEY ?? '',
@@ -110,7 +110,7 @@ Or add `fetchMailchimpData` to an API route in your non-Next framework
 
 ```ts
 // my-nuxt-app/server/api/mailchimp.ts
-import {fetchMailchimpData} from '@sanity/form-toolkit'
+import {fetchMailchimpData} from '@sanity/form-toolkit/mailchimp'
 
 export default defineEventHandler(async (event) => {
   const req = event.node.req
@@ -128,7 +128,7 @@ Add it as a plugin in `sanity.config.ts` (or .js):
 
 ```ts
 import {defineConfig} from 'sanity'
-import {mailchimpInput} from '@sanity/form-toolkit'
+import {mailchimpInput} from '@sanity/form-toolkit/mailchimp'
 
 export default defineConfig({
   //...
@@ -166,7 +166,7 @@ First add `formSchema` it as a plugin in `sanity.config.ts` (or .js):
 
 ```ts
 import {defineConfig} from 'sanity'
-import {formSchema} from '@sanity/form-toolkit'
+import {formSchema} from '@sanity/form-toolkit/form-schema'
 
 export default defineConfig({
   //...
@@ -178,7 +178,7 @@ Then pass a `form` document to the `FormRenderer` component
 
 ```tsx
 import React, {type FC} from 'react'
-import {FormRenderer, type FormDataProps} from '@sanity/form-toolkit'
+import {FormRenderer, type FormDataProps} from '@sanity/form-toolkit/form-schema'
 
 interface NativeFormExampleProps {
   formData: FormDataProps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/form-toolkit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/form-toolkit",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@formium/client": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       "formium": [

--- a/package.json
+++ b/package.json
@@ -24,10 +24,38 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.js"
     },
+    "./formium": {
+      "source": "./src/formium/index.ts",
+      "import": "./dist/formium/index.mjs",
+      "default": "./dist/formium/index.js"
+    },
+    "./hubspot": {
+      "source": "./src/hubspot/index.ts",
+      "import": "./dist/hubspot/index.mjs",
+      "default": "./dist/hubspot/index.js"
+    },
+    "./mailchimp": {
+      "source": "./src/mailchimp/index.ts",
+      "import": "./dist/mailchimp/index.mjs",
+      "default": "./dist/mailchimp/index.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "formium": [
+        "./dist/formium/index.d.ts"
+      ],
+      "hubspot": [
+        "./dist/hubspot/index.d.ts"
+      ],
+      "mailchimp": [
+        "./dist/mailchimp/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "sanity.json",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
   "sideEffects": false,
   "type": "commonjs",
   "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
-    },
     "./formium": {
       "source": "./src/formium/index.ts",
       "import": "./dist/formium/index.mjs",
@@ -39,6 +34,11 @@
       "import": "./dist/mailchimp/index.mjs",
       "default": "./dist/mailchimp/index.js"
     },
+    "./form-schema": {
+      "source": "./src/form-schema/index.ts",
+      "import": "./dist/form-schema/index.mjs",
+      "default": "./dist/form-schema/index.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
@@ -53,6 +53,9 @@
       ],
       "mailchimp": [
         "./dist/mailchimp/index.d.ts"
+      ],
+      "form-schema": [
+        "./dist/form-schema/index.d.ts"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/form-toolkit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Tool kit for integrating forms with a Sanity Studio",
   "keywords": [
     "sanity",
@@ -110,7 +110,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "react": "^18",
+    "react": "^18 || ^19",
     "sanity": "^3"
   },
   "engines": {

--- a/src/form-schema/components/form-renderer.tsx
+++ b/src/form-schema/components/form-renderer.tsx
@@ -4,7 +4,7 @@ import {DefaultField} from './default-field'
 import type {FieldComponentProps, FieldState, FormDataProps, FormField} from './types'
 
 interface FormRendererProps extends HTMLProps<HTMLFormElement> {
-  formData: FormDataProps
+  formData?: FormDataProps
   // Function to get field state for a given field name
   getFieldState?: (fieldName: string) => FieldState
   // Function to get field error for a given field name
@@ -36,10 +36,15 @@ export const FormRenderer: FC<FormRendererProps> = (props) => {
 
     return <DefaultField field={field} fieldState={fieldState} error={error} />
   }
+  const elProps = Object.assign({}, props)
+  delete elProps.formData
+  delete elProps.getFieldState
+  delete elProps.getFieldError
+  delete elProps.fieldComponents
 
   return (
-    <form {...props} id={props.id ?? formData?.id?.current}>
-      {formData.fields?.map((field) => (
+    <form {...elProps} id={elProps.id ?? formData?.id?.current}>
+      {formData?.fields?.map((field) => (
         <div key={field._key} className="form-field">
           {renderField(field)}
         </div>
@@ -47,7 +52,7 @@ export const FormRenderer: FC<FormRendererProps> = (props) => {
 
       {children}
 
-      <button type="submit">{formData.submitButton?.text || 'Submit'}</button>
+      <button type="submit">{formData?.submitButton?.text || 'Submit'}</button>
     </form>
   )
 }

--- a/src/form-schema/index.ts
+++ b/src/form-schema/index.ts
@@ -1,6 +1,6 @@
 import {definePlugin} from 'sanity'
-// import {structureTool} from 'sanity/structure'
 
+// import {structureTool} from 'sanity/structure'
 import {FormRenderer} from './components/form-renderer'
 import {schema} from './schema-types'
 // import {defaultDocumentNode} from './structure'
@@ -18,6 +18,7 @@ import {schema} from './schema-types'
  * })
  * ```
  */
+export type {FormDataProps} from './components/types'
 export {FormRenderer}
 export const formSchema = definePlugin(() => {
   return {

--- a/src/hubspot/index.ts
+++ b/src/hubspot/index.ts
@@ -2,7 +2,8 @@ import {asyncList} from '@sanity/sanity-plugin-async-list'
 import {definePlugin} from 'sanity'
 
 import {Option} from './components/option'
-
+import {hubSpotHandler} from './create-handler'
+import {fetchHubSpotData} from './fetch-hubspot-data'
 interface HubSpotInputConfig {
   url: string | URL
 }
@@ -12,7 +13,7 @@ interface HubSpotInputConfig {
  *
  * ```ts
  * import {defineConfig} from 'sanity'
- * import {hubSpotInput} from '@sanity/sanity-plugin-form-toolkit'
+ * import {hubSpotInput} from '@sanity/form-toolkit/hubspot'
  *
  * export default defineConfig({
  *   // ...
@@ -24,8 +25,9 @@ interface HubSpotInputConfig {
  * })
  * ```
  */
-type ExtendedOption = {value: string; name: string}
 
+type ExtendedOption = {value: string; name: string}
+export {fetchHubSpotData, hubSpotHandler}
 export const hubSpotInput = definePlugin<HubSpotInputConfig>((options) => {
   return {
     name: 'sanity-plugin-form-toolkit_hubspot-input',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,19 @@
-import {FormRenderer, formSchema} from './form-schema'
-import type {FormDataProps} from './form-schema/components/types'
-import {hubSpotInput} from './hubspot'
-import {hubSpotHandler} from './hubspot/create-handler'
-import {fetchHubSpotData} from './hubspot/fetch-hubspot-data'
-import {mailchimpInput} from './mailchimp'
-import {fetchMailchimpData, mailchimpHandler} from './mailchimp/create-handler'
+// import {FormRenderer, formSchema} from './form-schema'
+// import type {FormDataProps} from './form-schema/components/types'
+// import {hubSpotInput} from './hubspot'
+// import {hubSpotHandler} from './hubspot/create-handler'
+// import {fetchHubSpotData} from './hubspot/fetch-hubspot-data'
+// import {mailchimpInput} from './mailchimp'
+// import {fetchMailchimpData, mailchimpHandler} from './mailchimp/create-handler'
 
-export {
-  fetchHubSpotData,
-  fetchMailchimpData,
-  type FormDataProps,
-  FormRenderer,
-  formSchema,
-  hubSpotHandler,
-  hubSpotInput,
-  mailchimpHandler,
-  mailchimpInput,
-}
+// export {
+//   fetchHubSpotData,
+//   fetchMailchimpData,
+//   type FormDataProps,
+//   FormRenderer,
+//   formSchema,
+//   hubSpotHandler,
+//   hubSpotInput,
+//   mailchimpHandler,
+//   mailchimpInput,
+// }

--- a/src/mailchimp/index.ts
+++ b/src/mailchimp/index.ts
@@ -2,7 +2,8 @@ import {asyncList} from '@sanity/sanity-plugin-async-list'
 import {definePlugin} from 'sanity'
 
 import {Option} from './components/option'
-
+import {mailchimpHandler} from './create-handler'
+import {fetchMailchimpData} from './create-handler'
 interface MailchimpInputConfig {
   url: string | URL
 }
@@ -12,15 +13,15 @@ interface MailchimpInputConfig {
  *
  * ```ts
  * import {defineConfig} from 'sanity'
- * import {formiumInput} from 'sanity-plugin-form-toolkit'
+ * import {mailchimpInput} from '@sanity/form-toolkit/mailchimp'
  *
  * export default defineConfig({
  *   // ...
- *   plugins: [formiumInput()],
+ *   plugins: [mailchimpInput()],
  * })
  * ```
  */
-
+export {fetchMailchimpData, mailchimpHandler}
 export const mailchimpInput = definePlugin<MailchimpInputConfig>((options) => {
   return {
     name: 'sanity-plugin-form-toolkit_mailchimp-input',


### PR DESCRIPTION
BREAKING CHANGE: Import provider-specific plugin and helpers from provider export.