### PR TITLE
fix(deps): allow studio v4 in peer dep ranges + update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Semantic release
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: app-token
         with:
           app-id: ${{ secrets.ECOSPARK_APP_ID }}
@@ -128,9 +128,6 @@ jobs:
         # Branches that will release new versions are defined in .releaserc.json
         # @TODO remove --dry-run after verifying everything is good to go
       - run: npx semantic-release
-        # Don't allow interrupting the release step if the job is cancelled, as it can lead to an inconsistent state
-        # e.g. git tags were pushed but it exited before `npm publish`
-        if: always()
         env:
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19",
-        "sanity": "^3"
+        "sanity": "^3 || ^4.0.0-0"
       }
     },
     "node_modules/@actions/core": {
@@ -17638,6 +17638,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -17655,6 +17656,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17666,13 +17668,15 @@
       "version": "9.2.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -17690,6 +17694,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -17705,6 +17710,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -17716,13 +17722,15 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -17739,6 +17747,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^4.0.0",
@@ -17788,6 +17797,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/map-workspaces": "^4.0.1",
         "@npmcli/package-json": "^6.0.1",
@@ -17807,6 +17817,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -17819,6 +17830,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^8.0.0",
         "ini": "^5.0.0",
@@ -17839,6 +17851,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-bundled": "^4.0.0",
         "npm-normalize-package-bin": "^4.0.0"
@@ -17855,6 +17868,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/name-from-folder": "^3.0.0",
         "@npmcli/package-json": "^6.0.0",
@@ -17870,6 +17884,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cacache": "^19.0.0",
         "json-parse-even-better-errors": "^4.0.0",
@@ -17886,6 +17901,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -17917,6 +17933,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -17926,6 +17943,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -17935,6 +17953,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "glob": "^10.2.2",
@@ -17953,6 +17972,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "which": "^5.0.0"
       },
@@ -17965,6 +17985,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^6.1.2"
       },
@@ -17977,6 +17998,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -17986,6 +18008,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/node-gyp": "^4.0.0",
         "@npmcli/package-json": "^6.0.0",
@@ -18004,6 +18027,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -18013,6 +18037,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
@@ -18022,6 +18047,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.3.2",
         "tuf-js": "^3.0.1"
@@ -18035,6 +18061,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
@@ -18044,6 +18071,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -18053,6 +18081,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -18065,6 +18094,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -18078,6 +18108,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18087,6 +18118,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18098,25 +18130,29 @@
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cmd-shim": "^7.0.0",
         "npm-normalize-package-bin": "^4.0.0",
@@ -18133,6 +18169,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -18145,6 +18182,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -18154,6 +18192,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
@@ -18177,6 +18216,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18186,6 +18226,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4",
         "rimraf": "^5.0.5"
@@ -18199,6 +18240,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -18214,6 +18256,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -18226,6 +18269,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -18243,6 +18287,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18252,6 +18297,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -18264,6 +18310,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -18279,6 +18326,7 @@
       ],
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18288,6 +18336,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "ip-regex": "^5.0.0"
       },
@@ -18300,6 +18349,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -18309,6 +18359,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1"
@@ -18322,6 +18373,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -18331,6 +18383,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -18342,19 +18395,22 @@
       "version": "1.1.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -18369,6 +18425,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -18384,6 +18441,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -18396,6 +18454,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -18413,6 +18472,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -18421,13 +18481,15 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
@@ -18435,6 +18497,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -18444,6 +18507,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -18452,19 +18516,22 @@
       "version": "2.0.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
       "dev": true,
       "inBundle": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -18474,6 +18541,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -18490,6 +18558,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -18502,6 +18571,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -18521,13 +18591,15 @@
       "version": "4.2.11",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.0.1"
       },
@@ -18539,13 +18611,15 @@
       "version": "4.1.1",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -18559,6 +18633,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -18573,6 +18648,7 @@
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -18585,6 +18661,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minimatch": "^9.0.0"
       },
@@ -18597,6 +18674,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -18606,6 +18684,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18615,6 +18694,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -18624,6 +18704,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/package-json": "^6.0.0",
         "npm-package-arg": "^12.0.0",
@@ -18642,6 +18723,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -18655,6 +18737,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -18667,6 +18750,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "cidr-regex": "^4.1.1"
       },
@@ -18679,6 +18763,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18687,13 +18772,15 @@
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -18708,13 +18795,15 @@
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -18724,6 +18813,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -18735,25 +18825,29 @@
         "node >= 0.2.0"
       ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-package-arg": "^12.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -18767,6 +18861,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -18786,6 +18881,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.0",
         "@npmcli/run-script": "^9.0.1",
@@ -18807,6 +18903,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.0"
       },
@@ -18819,6 +18916,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -18832,6 +18930,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -18845,6 +18944,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^8.0.0",
         "@npmcli/run-script": "^9.0.1",
@@ -18860,6 +18960,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ci-info": "^4.0.0",
         "normalize-package-data": "^7.0.0",
@@ -18879,6 +18980,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^18.0.1"
       },
@@ -18891,6 +18993,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^18.0.1"
@@ -18904,6 +19007,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.1",
         "@npmcli/run-script": "^9.0.1",
@@ -18919,13 +19023,15 @@
       "version": "10.4.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/agent": "^3.0.0",
         "cacache": "^19.0.1",
@@ -18948,6 +19054,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -18957,6 +19064,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -18972,6 +19080,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -18981,6 +19090,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -18993,6 +19103,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
@@ -19010,6 +19121,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4",
         "rimraf": "^5.0.5"
@@ -19023,6 +19135,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -19035,6 +19148,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -19047,6 +19161,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -19059,6 +19174,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -19071,6 +19187,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -19083,6 +19200,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -19095,6 +19213,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -19108,6 +19227,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -19120,6 +19240,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -19131,13 +19252,15 @@
       "version": "2.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -19147,6 +19270,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -19171,6 +19295,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19180,6 +19305,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4",
         "rimraf": "^5.0.5"
@@ -19193,6 +19319,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -19208,6 +19335,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -19225,6 +19353,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19234,6 +19363,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "abbrev": "^2.0.0"
       },
@@ -19249,6 +19379,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -19258,6 +19389,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^8.0.0",
         "semver": "^7.3.5",
@@ -19272,6 +19404,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -19281,6 +19414,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-normalize-package-bin": "^4.0.0"
       },
@@ -19293,6 +19427,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "semver": "^7.1.1"
       },
@@ -19305,6 +19440,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -19314,6 +19450,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^8.0.0",
         "proc-log": "^5.0.0",
@@ -19329,6 +19466,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ignore-walk": "^7.0.0"
       },
@@ -19341,6 +19479,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-install-checks": "^7.1.0",
         "npm-normalize-package-bin": "^4.0.0",
@@ -19356,6 +19495,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^18.0.0",
         "proc-log": "^5.0.0"
@@ -19369,6 +19509,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/redact": "^3.0.0",
         "jsonparse": "^1.3.1",
@@ -19388,6 +19529,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4",
         "rimraf": "^5.0.5"
@@ -19401,6 +19543,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -19410,6 +19553,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -19424,13 +19568,15 @@
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "19.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^6.0.0",
         "@npmcli/installed-package-contents": "^3.0.0",
@@ -19462,6 +19608,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^4.0.0",
         "just-diff": "^6.0.0",
@@ -19476,6 +19623,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -19485,6 +19633,7 @@
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -19501,6 +19650,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -19514,6 +19664,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -19523,6 +19674,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -19532,6 +19684,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -19541,6 +19694,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
@@ -19549,13 +19703,15 @@
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -19569,6 +19725,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "read": "^4.0.0"
       },
@@ -19580,6 +19737,7 @@
       "version": "0.12.0",
       "dev": true,
       "inBundle": true,
+      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
@@ -19589,6 +19747,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "mute-stream": "^2.0.0"
       },
@@ -19601,6 +19760,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -19610,6 +19770,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^4.0.0",
         "npm-normalize-package-bin": "^4.0.0"
@@ -19623,6 +19784,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -19632,6 +19794,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^10.3.7"
       },
@@ -19647,13 +19810,15 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.6.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -19666,6 +19831,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -19678,6 +19844,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -19687,6 +19854,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -19699,6 +19867,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.0.0",
         "@sigstore/core": "^2.0.0",
@@ -19716,6 +19885,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.3.2"
       },
@@ -19728,6 +19898,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -19737,6 +19908,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.0.0",
         "@sigstore/core": "^2.0.0",
@@ -19754,6 +19926,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^3.0.0",
         "@sigstore/core": "^2.0.0",
@@ -19768,6 +19941,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -19778,6 +19952,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -19792,6 +19967,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.1",
         "debug": "^4.3.4",
@@ -19806,6 +19982,7 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -19816,6 +19993,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -19825,13 +20003,15 @@
       "version": "2.5.0",
       "dev": true,
       "inBundle": true,
-      "license": "CC-BY-3.0"
+      "license": "CC-BY-3.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -19841,19 +20021,22 @@
       "version": "3.0.20",
       "dev": true,
       "inBundle": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -19866,6 +20049,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -19881,6 +20065,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -19895,6 +20080,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -19908,6 +20094,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -19920,6 +20107,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19932,6 +20120,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -19949,6 +20138,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -19961,6 +20151,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -19973,6 +20164,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -19981,19 +20173,22 @@
       "version": "0.2.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -20003,6 +20198,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/models": "3.0.1",
         "debug": "^4.3.6",
@@ -20017,6 +20213,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
         "minimatch": "^9.0.5"
@@ -20030,6 +20227,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "unique-slug": "^5.0.0"
       },
@@ -20042,6 +20240,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -20053,13 +20252,15 @@
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -20070,6 +20271,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -20080,6 +20282,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -20088,13 +20291,15 @@
       "version": "3.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -20110,6 +20315,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -20119,6 +20325,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -20137,6 +20344,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -20154,6 +20362,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -20169,6 +20378,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20180,13 +20390,15 @@
       "version": "9.2.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -20204,6 +20416,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -20219,6 +20432,7 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -20231,7 +20445,8 @@
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/nth-check": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19",
-    "sanity": "^3"
+    "sanity": "^3 || ^4.0.0-0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```
Progress: resolved 1030, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.

```
This fixes it.

### Testing

Tested locally
